### PR TITLE
feat: add ts/consistent-type-definitions rule

### DIFF
--- a/mod.ts
+++ b/mod.ts
@@ -49,6 +49,7 @@ export function ryoppippi(
       rules: {
         /* eslint rules */
         "eqeqeq": ["error", "always", { null: "ignore" }],
+        "ts/consistent-type-definitions": ["error", "type"],
         "no-unexpected-multiline": "error",
         "no-unreachable": "error",
         "no-unused-vars": ["error", {


### PR DESCRIPTION
This commit introduces a new rule to the ESLint configuration. The
"ts/consistent-type-definitions" rule is set to "error" and "type",
enforcing consistent usage of type aliases over interfaces.

## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review

- [ ] Did you implement the changes in the correct branch?
- [ ] Is JSDocs for your new implementation up to date?
- [ ] Did you add tests for your changes?
- [ ] Did you update the documentation?
- [ ] Did all CI checks pass?
