### PR TITLE
fix: optimize tailwind plugin import

### DIFF
--- a/src/tailwindcss.ts
+++ b/src/tailwindcss.ts
@@ -4,11 +4,11 @@ import { interopDefault } from '@antfu/eslint-config';
  * Tailwind CSS configuration.
  */
 export async function tailwind(enabled: boolean = false) {
-	const pluginTailwindcss = await interopDefault(import('eslint-plugin-tailwindcss'));
-
 	if (!enabled) {
 		return [];
 	}
+
+	const pluginTailwindcss = await interopDefault(import('eslint-plugin-tailwindcss'));
 	return [
 		...pluginTailwindcss.configs['flat/recommended'],
 		{


### PR DESCRIPTION
Move the tailwind plugin import after the early return condition to avoid
unnecessary imports when tailwind is not enabled, improving performance.

## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review

- [ ] Did you implement the changes in the correct branch?
- [ ] Is JSDocs for your new implementation up to date?
- [ ] Did you add tests for your changes?
- [ ] Did you update the documentation?
- [ ] Did all CI checks pass?
