### PR TITLE
feat: add TanStack Query ESLint plugin integration

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -6,6 +6,7 @@ const { ryoppippi } = await importx('@ryoppippi/eslint-config', import.meta.url)
 export default ryoppippi({
 	svelte: false,
 	tailwind: true,
+	tanstackQuery: true,
 	typescript: {
 		tsconfigPath: './tsconfig.json',
 	},

--- a/package.json
+++ b/package.json
@@ -36,11 +36,15 @@
 	},
 	"peerDependencies": {
 		"@next/eslint-plugin-next": "^15.2.4",
+		"@tanstack/eslint-plugin-query": ">= 4",
 		"eslint": ">= 9.23.0",
 		"eslint-plugin-tailwindcss": "^3.18.0"
 	},
 	"peerDependenciesMeta": {
 		"@next/eslint-plugin-next": {
+			"optional": true
+		},
+		"@tanstack/eslint-plugin-query": {
 			"optional": true
 		},
 		"eslint-plugin-tailwindcss": {
@@ -56,6 +60,7 @@
 	},
 	"devDependencies": {
 		"@next/eslint-plugin-next": "^15.2.4",
+		"@tanstack/eslint-plugin-query": "^5.68.0",
 		"@types/eslint-plugin-tailwindcss": "^3.17.0",
 		"clean-pkg-json": "^1.2.1",
 		"eslint": "^9.23.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,6 +30,9 @@ importers:
       '@next/eslint-plugin-next':
         specifier: ^15.2.4
         version: 15.2.4
+      '@tanstack/eslint-plugin-query':
+        specifier: ^5.68.0
+        version: 5.68.0(eslint@9.23.0(jiti@2.4.2))(typescript@5.8.2)
       '@types/eslint-plugin-tailwindcss':
         specifier: ^3.17.0
         version: 3.17.0
@@ -761,6 +764,11 @@ packages:
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: '>=9.0.0'
+
+  '@tanstack/eslint-plugin-query@5.68.0':
+    resolution: {integrity: sha512-w/+y5LILV1GTWBB2R/lKfUzgocKXU1B7O6jipLUJhmxCKPmJFy5zpfR1Vx7c6yCEsQoKcTbhuR/tIy+1sIGaiA==}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0
 
   '@trysound/sax@0.2.0':
     resolution: {integrity: sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA==}
@@ -3311,6 +3319,14 @@ snapshots:
       espree: 10.3.0
       estraverse: 5.3.0
       picomatch: 4.0.2
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+
+  '@tanstack/eslint-plugin-query@5.68.0(eslint@9.23.0(jiti@2.4.2))(typescript@5.8.2)':
+    dependencies:
+      '@typescript-eslint/utils': 8.27.0(eslint@9.23.0(jiti@2.4.2))(typescript@5.8.2)
+      eslint: 9.23.0(jiti@2.4.2)
     transitivePeerDependencies:
       - supports-color
       - typescript

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ import type { ESLintConfig, UserConfigs, UserOptions } from './options';
 import antfu from '@antfu/eslint-config';
 import { defu } from 'defu';
 import { resolveTSConfig } from 'pkg-types';
-import { next, tailwindCss } from './rules';
+import { next, tailwindCss, tanstackQuery } from './rules';
 
 /**
  * @ryoppippi's ESLint configuration.
@@ -62,6 +62,7 @@ export async function ryoppippi(
 
 	const tailwindRules = await tailwindCss(_options.tailwindcss);
 	const nextJsRules = await next(_options.next);
+	const tanstackQueryRules = await tanstackQuery(_options.tanstackQuery);
 
 	return antfu(
 		_options as UserOptions,
@@ -76,6 +77,7 @@ export async function ryoppippi(
 		},
 		...tailwindRules,
 		...nextJsRules,
+		...tanstackQueryRules,
 		/* svelte rules */
 		(!_options.svelte)
 			? {}

--- a/src/options.ts
+++ b/src/options.ts
@@ -21,6 +21,16 @@ export type UserOptions = Parameters<typeof antfu>[0] & {
 	 * @default false
 	 */
 	next?: boolean;
+
+	/**
+	 * Enable tanstackQuery rules.
+	 *
+	 * Requires installing:
+	 * - `@tanstack/eslint-plugin-tanstackQuery`
+	 *
+	 * @default false
+	 */
+	tanstackQuery?: boolean;
 };
 export type UserConfigs = Parameters<typeof antfu>[1];
 export type ESLintConfig = ReturnType<typeof antfu>;

--- a/src/rules/index.ts
+++ b/src/rules/index.ts
@@ -1,2 +1,3 @@
 export * from './next';
 export * from './tailwindcss';
+export * from './tanstackQuery';

--- a/src/rules/tanstackQuery.ts
+++ b/src/rules/tanstackQuery.ts
@@ -1,0 +1,14 @@
+import type { TypedFlatConfigItem } from '@antfu/eslint-config';
+
+import { interopDefault } from '@antfu/eslint-config';
+
+export async function tanstackQuery(enabled: boolean = false): Promise<TypedFlatConfigItem[]> {
+	if (!enabled) {
+		return [];
+	}
+
+	const pluginTanstackQuery = await interopDefault(import('@tanstack/eslint-plugin-query'));
+	return [
+		...pluginTanstackQuery.configs['flat/recommended'],
+	];
+}


### PR DESCRIPTION
Add support for TanStack Query ESLint rules by:
- Adding @tanstack/eslint-plugin-query as optional peer dependency
- Creating tanstackQuery.ts rule module that conditionally loads the plugin
- Adding tanstackQuery configuration option to UserOptions
- Integrating TanStack Query rules into the main config

This allows users to enable TanStack Query specific ESLint rules when
using the library by setting the tanstackQuery option to true.