### PR TITLE
feat: add TanStack Router ESLint plugin integration

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -7,6 +7,7 @@ export default ryoppippi({
 	svelte: false,
 	tailwind: true,
 	tanstackQuery: true,
+	tanstackRouter: true,
 	typescript: {
 		tsconfigPath: './tsconfig.json',
 	},

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
 	"peerDependencies": {
 		"@next/eslint-plugin-next": "^15.2.4",
 		"@tanstack/eslint-plugin-query": ">= 4.38.0",
+		"@tanstack/eslint-plugin-router": ">= 1",
 		"eslint": ">= 9.23.0",
 		"eslint-plugin-tailwindcss": "^3.18.0"
 	},
@@ -45,6 +46,9 @@
 			"optional": true
 		},
 		"@tanstack/eslint-plugin-query": {
+			"optional": true
+		},
+		"@tanstack/eslint-plugin-router": {
 			"optional": true
 		},
 		"eslint-plugin-tailwindcss": {
@@ -61,6 +65,7 @@
 	"devDependencies": {
 		"@next/eslint-plugin-next": "^15.2.4",
 		"@tanstack/eslint-plugin-query": "^5.68.0",
+		"@tanstack/eslint-plugin-router": "^1.114.29",
 		"@types/eslint-plugin-tailwindcss": "^3.17.0",
 		"clean-pkg-json": "^1.2.1",
 		"eslint": "^9.23.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,6 +33,9 @@ importers:
       '@tanstack/eslint-plugin-query':
         specifier: ^5.68.0
         version: 5.68.0(eslint@9.23.0(jiti@2.4.2))(typescript@5.8.2)
+      '@tanstack/eslint-plugin-router':
+        specifier: ^1.114.29
+        version: 1.114.29(eslint@9.23.0(jiti@2.4.2))(typescript@5.8.2)
       '@types/eslint-plugin-tailwindcss':
         specifier: ^3.17.0
         version: 3.17.0
@@ -767,6 +770,11 @@ packages:
 
   '@tanstack/eslint-plugin-query@5.68.0':
     resolution: {integrity: sha512-w/+y5LILV1GTWBB2R/lKfUzgocKXU1B7O6jipLUJhmxCKPmJFy5zpfR1Vx7c6yCEsQoKcTbhuR/tIy+1sIGaiA==}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0
+
+  '@tanstack/eslint-plugin-router@1.114.29':
+    resolution: {integrity: sha512-eV1QY6TgNfl5O9NeV3vDY+lfT1KunmOivHAQd5MXqPyQd5wnw79LSdzf+8H6E4tjUFYhs6xttHTO+QSqJ8fzew==}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0
 
@@ -3324,6 +3332,14 @@ snapshots:
       - typescript
 
   '@tanstack/eslint-plugin-query@5.68.0(eslint@9.23.0(jiti@2.4.2))(typescript@5.8.2)':
+    dependencies:
+      '@typescript-eslint/utils': 8.27.0(eslint@9.23.0(jiti@2.4.2))(typescript@5.8.2)
+      eslint: 9.23.0(jiti@2.4.2)
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+
+  '@tanstack/eslint-plugin-router@1.114.29(eslint@9.23.0(jiti@2.4.2))(typescript@5.8.2)':
     dependencies:
       '@typescript-eslint/utils': 8.27.0(eslint@9.23.0(jiti@2.4.2))(typescript@5.8.2)
       eslint: 9.23.0(jiti@2.4.2)

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ import type { ESLintConfig, UserConfigs, UserOptions } from './options';
 import antfu from '@antfu/eslint-config';
 import { defu } from 'defu';
 import { resolveTSConfig } from 'pkg-types';
-import { next, tailwindCss, tanstackQuery } from './rules';
+import { next, tailwindCss, tanstackQuery, tanstackRouter } from './rules';
 
 /**
  * @ryoppippi's ESLint configuration.
@@ -63,6 +63,7 @@ export async function ryoppippi(
 	const tailwindRules = await tailwindCss(_options.tailwindcss);
 	const nextJsRules = await next(_options.next);
 	const tanstackQueryRules = await tanstackQuery(_options.tanstackQuery);
+	const tanstackRouterRules = await tanstackRouter(_options.tanstackRouter);
 
 	return antfu(
 		_options as UserOptions,
@@ -78,6 +79,7 @@ export async function ryoppippi(
 		...tailwindRules,
 		...nextJsRules,
 		...tanstackQueryRules,
+		...tanstackRouterRules,
 		/* svelte rules */
 		(!_options.svelte)
 			? {}

--- a/src/options.ts
+++ b/src/options.ts
@@ -31,6 +31,16 @@ export type UserOptions = Parameters<typeof antfu>[0] & {
 	 * @default false
 	 */
 	tanstackQuery?: boolean;
+
+	/**
+	 * Enable tanstackRouter rules.
+	 *
+	 * Requires installing:
+	 * - `@tanstack/eslint-plugin-router`
+	 *
+	 * @default false
+	 */
+	tanstackRouter?: boolean;
 };
 export type UserConfigs = Parameters<typeof antfu>[1];
 export type ESLintConfig = ReturnType<typeof antfu>;

--- a/src/rules/index.ts
+++ b/src/rules/index.ts
@@ -1,3 +1,4 @@
 export * from './next';
 export * from './tailwindcss';
 export * from './tanstackQuery';
+export * from './tanstackRouter';

--- a/src/rules/tanstackRouter.ts
+++ b/src/rules/tanstackRouter.ts
@@ -1,0 +1,14 @@
+import type { TypedFlatConfigItem } from '@antfu/eslint-config';
+
+import { interopDefault } from '@antfu/eslint-config';
+
+export async function tanstackRouter(enabled: boolean = false): Promise<TypedFlatConfigItem[]> {
+	if (!enabled) {
+		return [];
+	}
+
+	const pluginTanstackRouter = await interopDefault(import('@tanstack/eslint-plugin-router'));
+	return [
+		...pluginTanstackRouter.configs['flat/recommended'],
+	];
+}


### PR DESCRIPTION
Add support for ESLint rules from @tanstack/eslint-plugin-router in the
configuration. Users can now enable TanStack Router's recommended rules
by setting the `tanstackRouter` option to true.

This change follows the same pattern as other integrations (Query, Next.js,
Tailwind) for consistency in the API.