### PR TITLE
feat: ensure packages are installed

### DIFF
--- a/src/rules/next.ts
+++ b/src/rules/next.ts
@@ -1,12 +1,14 @@
 /* eslint-disable ts/no-unsafe-member-access */
 /* eslint-disable ts/no-unsafe-assignment */
 import type { TypedFlatConfigItem } from '@antfu/eslint-config';
-import { interopDefault } from '@antfu/eslint-config';
+import { ensurePackages, interopDefault } from '@antfu/eslint-config';
 
 export async function next(enabled = false): Promise<TypedFlatConfigItem[]> {
 	if (!enabled) {
 		return [];
 	}
+
+	await ensurePackages(['@next/eslint-plugin-next']);
 
 	// @ts-expect-error no dts
 	const nextPlugin: any = await interopDefault(import('@next/eslint-plugin-next'));

--- a/src/rules/ryoppippi.ts
+++ b/src/rules/ryoppippi.ts
@@ -1,11 +1,13 @@
 import type { TypedFlatConfigItem } from '@antfu/eslint-config';
 
-import { interopDefault } from '@antfu/eslint-config';
+import { ensurePackages, interopDefault } from '@antfu/eslint-config';
 
 export async function ryoppippi(enabled: boolean = false): Promise<TypedFlatConfigItem[]> {
 	if (!enabled) {
 		return [];
 	}
+
+	await ensurePackages(['eslint-plugin-ryoppippi']);
 
 	const pluginRyoppippi = await interopDefault(import('eslint-plugin-ryoppippi'));
 	return [

--- a/src/rules/tailwindcss.ts
+++ b/src/rules/tailwindcss.ts
@@ -1,5 +1,5 @@
 import type { TypedFlatConfigItem } from '@antfu/eslint-config';
-import { interopDefault } from '@antfu/eslint-config';
+import { ensurePackages, interopDefault } from '@antfu/eslint-config';
 
 export type TailwindCssOptions = {
 /**
@@ -17,6 +17,9 @@ export async function tailwindCss(options: TailwindCssOptions | boolean = false)
 	if (options === false) {
 		return [];
 	}
+
+	await ensurePackages(['eslint-plugin-tailwindcss']);
+
 	if (options === true) {
 		options = {};
 	}

--- a/src/rules/tanstackQuery.ts
+++ b/src/rules/tanstackQuery.ts
@@ -1,11 +1,13 @@
 import type { TypedFlatConfigItem } from '@antfu/eslint-config';
 
-import { interopDefault } from '@antfu/eslint-config';
+import { ensurePackages, interopDefault } from '@antfu/eslint-config';
 
 export async function tanstackQuery(enabled: boolean = false): Promise<TypedFlatConfigItem[]> {
 	if (!enabled) {
 		return [];
 	}
+
+	await ensurePackages(['@tanstack/eslint-plugin-query']);
 
 	const pluginTanstackQuery = await interopDefault(import('@tanstack/eslint-plugin-query'));
 	return [

--- a/src/rules/tanstackRouter.ts
+++ b/src/rules/tanstackRouter.ts
@@ -1,11 +1,13 @@
 import type { TypedFlatConfigItem } from '@antfu/eslint-config';
 
-import { interopDefault } from '@antfu/eslint-config';
+import { ensurePackages, interopDefault } from '@antfu/eslint-config';
 
 export async function tanstackRouter(enabled: boolean = false): Promise<TypedFlatConfigItem[]> {
 	if (!enabled) {
 		return [];
 	}
+
+	await ensurePackages(['@tanstack/eslint-plugin-query']);
 
 	const pluginTanstackRouter = await interopDefault(import('@tanstack/eslint-plugin-router'));
 	return [


### PR DESCRIPTION
This pull request includes updates to several rule files to ensure necessary packages are installed before importing ESLint plugins. The main changes involve adding calls to `ensurePackages` to install the required plugins dynamically.

### Ensuring necessary packages are installed:

* [`src/rules/next.ts`](diffhunk://#diff-0a85e24fd60b733f6b3ed578d9b927281c5672c6a6ec7cc5db9925cf0f9a5f95L4-R12): Added `ensurePackages` to install `@next/eslint-plugin-next` before importing it.
* [`src/rules/ryoppippi.ts`](diffhunk://#diff-dc38a60d2ef5894d43fe647237fa2f2a16ab619a980b2f37bb980d4fadc29fb0L3-R11): Added `ensurePackages` to install `eslint-plugin-ryoppippi` before importing it.
* [`src/rules/tailwindcss.ts`](diffhunk://#diff-03e2fefba42ab33a269922ed66de8b720dc8adf94615d462b6a4a13cf9675ee4L2-R2): Added `ensurePackages` to install `eslint-plugin-tailwindcss` before importing it. [[1]](diffhunk://#diff-03e2fefba42ab33a269922ed66de8b720dc8adf94615d462b6a4a13cf9675ee4L2-R2) [[2]](diffhunk://#diff-03e2fefba42ab33a269922ed66de8b720dc8adf94615d462b6a4a13cf9675ee4R20-R22)
* [`src/rules/tanstackQuery.ts`](diffhunk://#diff-5bb605f3ed38b339a69aa47a0b6f413e8a6aeb598b527a301b263cb8f71c4dbeL3-R11): Added `ensurePackages` to install `@tanstack/eslint-plugin-query` before importing it.
* [`src/rules/tanstackRouter.ts`](diffhunk://#diff-3fe17d7a82139b433c618d3852f3b4d7855a35ae915681a66f10b0919cfd2012L3-R11): Added `ensurePackages` to install `@tanstack/eslint-plugin-query` before importing it.