### PR TITLE
feat(tanstack-router): add TanStack Start ESLint ignore configuration

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -8,6 +8,7 @@ export default ryoppippi({
 	tailwind: true,
 	tanstackQuery: true,
 	tanstackRouter: true,
+	tanstackStart: true,
 	typescript: {
 		tsconfigPath: './tsconfig.json',
 	},

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ import type { ESLintConfig, UserConfigs, UserOptions } from './options';
 import antfu from '@antfu/eslint-config';
 import { defu } from 'defu';
 import { resolveTSConfig } from 'pkg-types';
-import { next, ryoppippi as ryoppippiRules, tailwindCss, tanstackQuery, tanstackRouter } from './rules';
+import { next, ryoppippi as ryoppippiRules, tailwindCss, tanstackQuery, tanstackRouter, tanstackStart } from './rules';
 
 /**
  * @ryoppippi's ESLint configuration.
@@ -60,10 +60,15 @@ export async function ryoppippi(
 		console.warn('tsconfig.json is not found. we cannot use type-aware rules.');
 	}
 
+	const enabledTanstackStart = _options.tanstackStart !== false;
+	const enableTanstackRouter = enabledTanstackStart && _options.tanstackRouter !== false;
+	const enableTanstackQuery = enabledTanstackStart && _options.tanstackQuery !== false;
+
 	const tailwindRules = await tailwindCss(_options.tailwindcss);
 	const nextJsRules = await next(_options.next);
-	const tanstackQueryRules = await tanstackQuery(_options.tanstackQuery);
-	const tanstackRouterRules = await tanstackRouter(_options.tanstackRouter);
+	const tanstackStartRules = await tanstackStart(_options.tanstackStart);
+	const tanstackQueryRules = await tanstackQuery(enableTanstackQuery);
+	const tanstackRouterRules = await tanstackRouter(enableTanstackRouter);
 	const pluginRyoppippi = await ryoppippiRules(true);
 
 	return antfu(
@@ -82,6 +87,7 @@ export async function ryoppippi(
 		...nextJsRules,
 		...tanstackQueryRules,
 		...tanstackRouterRules,
+		...tanstackStartRules,
 		/* svelte rules */
 		(!_options.svelte)
 			? {}

--- a/src/options.ts
+++ b/src/options.ts
@@ -1,5 +1,5 @@
 import type antfu from '@antfu/eslint-config';
-import type { TailwindCssOptions } from './rules';
+import type { TailwindCssOptions, TanstackStartOptions } from './rules';
 
 export type UserOptions = Parameters<typeof antfu>[0] & {
 	/**
@@ -41,6 +41,16 @@ export type UserOptions = Parameters<typeof antfu>[0] & {
 	 * @default false
 	 */
 	tanstackRouter?: boolean;
+
+	/**
+	 * Enable tanstackStart rules.
+	 *
+	 * This auto enabled `@tanstack/eslint-plugin-router` and `@tanstack/eslint-plugin-tanstackQuery`
+	 * If you want to disable them, you can set `tanstackQuery` and `tanstackRouter` to `false`
+	 *
+	 * @default false
+	 */
+	tanstackStart?: boolean | TanstackStartOptions;
 };
 export type UserConfigs = Parameters<typeof antfu>[1];
 export type ESLintConfig = ReturnType<typeof antfu>;

--- a/src/rules/index.ts
+++ b/src/rules/index.ts
@@ -3,3 +3,4 @@ export * from './ryoppippi';
 export * from './tailwindcss';
 export * from './tanstackQuery';
 export * from './tanstackRouter';
+export * from './tanstackStart';

--- a/src/rules/tanstackStart.ts
+++ b/src/rules/tanstackStart.ts
@@ -1,0 +1,35 @@
+import type { TypedFlatConfigItem } from '@antfu/eslint-config';
+
+export type TanstackStartOptions = {
+	/**
+	 * The directory where the app is located
+	 *
+	 * @default 'app'
+	 */
+	appDirectory?: string;
+};
+
+export async function tanstackStart(options: TanstackStartOptions | boolean = false): Promise<TypedFlatConfigItem[]> {
+	if (options === false) {
+		return [];
+	}
+
+	if (options === true) {
+		options = {};
+	}
+
+	const {
+		appDirectory = 'app',
+	} = options;
+
+	return [
+		{
+			ignores: [
+				`${appDirectory}/client.tsx`,
+				`${appDirectory}/ssr.tsx`,
+				`${appDirectory}/router.tsx`,
+				`${appDirectory}/routeTree.gen.ts`,
+			],
+		},
+	];
+}


### PR DESCRIPTION
This adds a new ESLint config option `tanstackStart` which:
- Automatically enables TanStack Query and Router plugins
- Ignores TanStack generated files in the app directory
- Allows customizing the app directory path
- Prevents ESLint errors in TanStack-generated files for better DX